### PR TITLE
Fix maxFib and remove duplicate function

### DIFF
--- a/src/server/BitBuffer.lua
+++ b/src/server/BitBuffer.lua
@@ -63,10 +63,6 @@ function Reader:__tostring()
 	return "BitReader(" .. self._head .. "/" .. self._totalLen .. "): " .. self._origin
 end
 
-function Reader:getHead()
-	return self._head
-end
-
 
 
 

--- a/src/server/BitBuffer.lua
+++ b/src/server/BitBuffer.lua
@@ -348,8 +348,8 @@ for i = 1, 32 do
 	fibSeq[i] = a0
 end
 
-Reader.maxFib = a1 - 1 -- ehh why not
-Writer.maxFib = a1 - 1
+Reader.maxFib = a0 - 1 -- ehh why not
+Writer.maxFib = a0 - 1
 
 function Writer:writeFib(n)
 	local c


### PR DESCRIPTION
Fixes the maxFib check in [EncoderFuncs](https://github.com/AxisAngles/EncoderV2/blob/cd77d78bf29a64ec25e0ead7e7a5e10601978084/src/server/EncoderFuncs.lua#L99) by referencing the correct value in the bitwriter.
Also removed a duplicate reader:getHead function in the bitwriter.